### PR TITLE
Prevent usage plan creation

### DIFF
--- a/requests_ip_rotator/ip_rotator.py
+++ b/requests_ip_rotator/ip_rotator.py
@@ -162,19 +162,6 @@ class ApiGateway(rq.adapters.HTTPAdapter):
             stageName="ProxyStage"
         )
 
-        # Create simple usage plan
-        # TODO: Cleanup usage plans on delete
-        awsclient.create_usage_plan(
-            name="burpusage",
-            description=rest_api_id,
-            apiStages=[
-                {
-                    "apiId": rest_api_id,
-                    "stage": "ProxyStage"
-                }
-            ]
-        )
-
         # Return endpoint name and whether it show it is newly created
         return {
             "success": True,


### PR DESCRIPTION
Currently, creating gateways also create matching usage plans that get left dangling even after gateway deletion. Since these aren't used at all, this PR prevents their creation to begin with. This was legacy code copied from RhinoSecurityLabs' Burp Rotator.