### PR TITLE
Pass keyword arguments to parent transport adaptor

### DIFF
--- a/requests_ip_rotator/ip_rotator.py
+++ b/requests_ip_rotator/ip_rotator.py
@@ -30,8 +30,8 @@ ALL_REGIONS = EXTRA_REGIONS + [
 # Inherits from HTTPAdapter so that we can edit each request before sending
 class ApiGateway(rq.adapters.HTTPAdapter):
 
-    def __init__(self, site, regions=DEFAULT_REGIONS, access_key_id=None, access_key_secret=None):
-        super().__init__()
+    def __init__(self, site, regions=DEFAULT_REGIONS, access_key_id=None, access_key_secret=None, **kwargs):
+        super().__init__(**kwargs)
         # Set simple params from constructor
         if site.endswith("/"):
             self.site = site[:-1]


### PR DESCRIPTION
Pass keyword arguments to parent transport adaptor (`HTTPAdapter`) so arguments like `max_retries` can be passed to the Gateway. max_retries can point to an instance of Retry from the `urllib3.util.retry`. I was required to use it on a project and it seems like a useful addition.

Code I'm using:

```python
from urllib3.util.retry import Retry

retries = Retry(
    total=5, 
    status_forcelist=[ 301 ],
    allowed_methods=['GET', 'HEAD']
)

# Slightly adapted the ApiGateway code to allow max_retries
with ApiGateway(hostname, regions=['eu-west-1','eu-west-2','eu-west-3','eu-north-1','eu-central-1'], max_retries=retries) as g:
    # Start a new session 
    session = requests.Session()
    session.mount(hostname, g)
    ......
```