### PR TITLE
Do not fail on name checking unnamed gateways

### DIFF
--- a/requests_ip_rotator/ip_rotator.py
+++ b/requests_ip_rotator/ip_rotator.py
@@ -94,7 +94,7 @@ class ApiGateway(rq.adapters.HTTPAdapter):
                     raise e
 
             for api in current_apis:
-                if self.api_name == api["name"]:
+                if self.api_name == api.get("name", None):
                     return {
                         "success": True,
                         "endpoint": f"{api['id']}.execute-api.{region}.amazonaws.com",
@@ -238,7 +238,7 @@ class ApiGateway(rq.adapters.HTTPAdapter):
         while api_iter < len(apis):
             api = apis[api_iter]
             # Check if hostname matches
-            if self.api_name == api["name"]:
+            if self.api_name == api.get("name", None):
                 # Attempt delete
                 try:
                     # If endpoints list is given, only delete if within list

--- a/requests_ip_rotator/ip_rotator.py
+++ b/requests_ip_rotator/ip_rotator.py
@@ -94,7 +94,7 @@ class ApiGateway(rq.adapters.HTTPAdapter):
                     raise e
 
             for api in current_apis:
-                if self.api_name == api.get("name", None):
+                if "name" in api and self.api_name == api["name"]:
                     return {
                         "success": True,
                         "endpoint": f"{api['id']}.execute-api.{region}.amazonaws.com",
@@ -238,7 +238,7 @@ class ApiGateway(rq.adapters.HTTPAdapter):
         while api_iter < len(apis):
             api = apis[api_iter]
             # Check if hostname matches
-            if self.api_name == api.get("name", None):
+            if "name" in api and self.api_name == api["name"]:
                 # Attempt delete
                 try:
                     # If endpoints list is given, only delete if within list


### PR DESCRIPTION
I have a gateway created by another service that has no name key which breaks init and deletion.

Would have assumed the name would be an empty string but apparently that's not the case in this instance.