### PR TITLE
Add Option to Require Manual Deletion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 # Custom #
 ##########
 .vscode/
+test.py
 
 ##################
 # Auto-generated #


### PR DESCRIPTION
When being used in prod, it can be important to avoid situations where existing endpoints are accidentally deleted via a `gateway.shutdown()`. For example, if endpoints are being stored separately and then reused to avoid pulling endpoints each time, deleting them can break an entire instance.
This PR introduces the `require_manual_shutdown` flag to `start()` which adds the string "(Manual Shutdown Required)" to the end of the gateways, and these will never be deleted during `shutdown()` instances!

Closes #45 