### PR TITLE
concurrent.futures deletion fix

### DIFF
--- a/requests_ip_rotator/ip_rotator.py
+++ b/requests_ip_rotator/ip_rotator.py
@@ -41,7 +41,6 @@ class ApiGateway(rq.adapters.HTTPAdapter):
             self.site = site
         self.access_key_id = access_key_id
         self.access_key_secret = access_key_secret
-
         self.api_name = site + api_name_suffix
         self.regions = regions
         self.verbose = verbose

--- a/requests_ip_rotator/ip_rotator.py
+++ b/requests_ip_rotator/ip_rotator.py
@@ -2,7 +2,6 @@ import concurrent.futures
 import ipaddress
 from random import choice, randint
 from time import sleep
-from datetime import datetime
 
 import boto3
 import botocore.exceptions
@@ -33,7 +32,7 @@ ALL_REGIONS = EXTRA_REGIONS + [
 # Inherits from HTTPAdapter so that we can edit each request before sending
 class ApiGateway(rq.adapters.HTTPAdapter):
 
-    def __init__(self, site, regions=DEFAULT_REGIONS, access_key_id=None, access_key_secret=None, verbose=True, **kwargs):
+    def __init__(self, site, regions=DEFAULT_REGIONS, access_key_id=None, access_key_secret=None, verbose=True, api_name_suffix: str=" - IP Rotate API", **kwargs):
         super().__init__(**kwargs)
         # Set simple params from constructor
         if site.endswith("/"):
@@ -43,9 +42,7 @@ class ApiGateway(rq.adapters.HTTPAdapter):
         self.access_key_id = access_key_id
         self.access_key_secret = access_key_secret
 
-        datetime_prefix = datetime.now().strftime('%Y-%m-%d_%H%M.%S')
-        random_prefix = randint(0,99999)
-        self.api_name = site + " - IP Rotate API" + datetime_prefix + "_" + str(random_prefix)
+        self.api_name = site + api_name_suffix
         self.regions = regions
         self.verbose = verbose
 

--- a/requests_ip_rotator/ip_rotator.py
+++ b/requests_ip_rotator/ip_rotator.py
@@ -2,6 +2,7 @@ import concurrent.futures
 import ipaddress
 from random import choice, randint
 from time import sleep
+from datetime import datetime
 
 import boto3
 import botocore.exceptions
@@ -41,7 +42,10 @@ class ApiGateway(rq.adapters.HTTPAdapter):
             self.site = site
         self.access_key_id = access_key_id
         self.access_key_secret = access_key_secret
-        self.api_name = site + " - IP Rotate API"
+
+        datetime_prefix = datetime.now().strftime('%Y-%m-%d_%H%M.%S')
+        random_prefix = randint(0,99999)
+        self.api_name = site + " - IP Rotate API" + datetime_prefix + "_" + str(random_prefix)
         self.regions = regions
         self.verbose = verbose
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ README = (location / "README.md").read_text()
 # This call to setup() does all the work
 setup(
     name="requests-ip-rotator",
-    version="1.0.15",
+    version="1.0.16",
     description="Rotate through IPs in Python using AWS API Gateway.",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
#77 
Per submitted issue, making the api_name unique through combination of datetime and random number will significantly reduce the chances of collision (aka same api_name)

Problem: When you utilize concurrent.futures as part of POC from #6 , the delete_gateway behavior will delete all ApiGateways with matching api_name. The api_name is just the site name and appended " - IP Rotate API" label. If you create multiple ApiGateways to same site, the delete behavior deletes all ApiGateways as they would all have the same api_name.

I do not believe having the same api_name causes issues when creating new ApiGateways as I believe I've seen multiple ApiGateways when viewing in AWS console. The deletion is the only issue.

Solution: By appending a datetime and random number from 0 to 99999, any collisions from matching api names should all but be eliminated (If you created 25 ApiGateway at the exact same second, the odds of any matching API names is 0.3%. Pair that with the odds that all 25 Gateways would be created at the exact same second, the odds get even lower of collision.